### PR TITLE
Remove the redundant $(var.ExeSourceFile) from ExeCommand

### DIFF
--- a/nextcloud.wxs
+++ b/nextcloud.wxs
@@ -55,7 +55,7 @@
                         Return="ignore"
                         Execute="deferred"
                         FileKey="File0"
-                        ExeCommand="$(var.ExeSourceFile) /S"
+                        ExeCommand="/S"
                         HideTarget="no"
                         Impersonate="no" />
                 <InstallExecuteSequence>


### PR DESCRIPTION
It actually adds the exe file name once again, resulting in a command that looks like:

    "C:\some_folder\setup.exe" setup.exe /S